### PR TITLE
set empty "proxies" variable to avoid undefined variable problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-_Update 2019-01-02 - Due to no longer working in a check_mk/slack environment I'm not best placed to maintain this - as of this update this script still works AFAIK, but I won't be able to accept any commits/updates going forward unless I land myself back in a similar environment!_
+This is a fork of rmblake's notification script found at https://github.com/rmblake/check_mk-slack
 
 This is a script designed to bounce Check_MK/OMD notifications 
 into a Slack Channel, using Slacks Incoming Webhooks API.

--- a/slack
+++ b/slack
@@ -24,6 +24,8 @@ else:
     channel = '#monitoring'
 bot_name = "CMKBot"
 
+proxies = {}
+# if a proxy is requied, uncomment ...
 #proxies = {
 #          "http"  : "http://proxy:3128",
 #          "https" : "http://proxy:3128"


### PR DESCRIPTION
if "requests.post" is used with "proxies=proxies" the variable "proxies" must be defined.
I set it to an empty dictionary to avoid errors.
Other possibility would've been to conditionally call it with or without proxies-parameter.